### PR TITLE
Update FusionNetworkingPlus.csproj

### DIFF
--- a/FusionNetworkingPlus.csproj
+++ b/FusionNetworkingPlus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyName>FNPlus</AssemblyName>
+    <AssemblyName>FNExtender</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
-    <RootNamespace>FNPlus</RootNamespace>
+    <RootNamespace>FNExtender</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
**Which feature did i add?**
To make full rebrand from FusionNetworkingExtender, I updated FusionNetworkingPlus.csproj to remove FNPlus branding from there.

**Why would this feature be useful?**
If someone wants to build FNExtender, it whould be shown as FNExtender, not FNplus.